### PR TITLE
Update workflow to trigger only on manual dispatch

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,9 +18,6 @@ name: Copilot Setup Steps
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - .github/workflows/copilot-setup-steps.yml
 
 jobs:
   copilot-setup-steps:


### PR DESCRIPTION
Removed push trigger for copilot-setup-steps workflow.